### PR TITLE
Add info about noresm2.1 development version

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -35,6 +35,8 @@ Scientifically supported NorESM versions
 Unsupported development versions
 """"""""""""""""""""""""""""""""
 
+`NorESM2.1 <https://noresm-docs.readthedocs.io/en/noresm2.1/>`_ :
+   Bugfix version that fixes some known bugs in NorESM2. This is a technical release that does not include model tuning for a balanced climate output.
 `NorESM2.2 <https://noresm-docs.readthedocs.io/en/noresm2.2/>`_ :
    Experimental development version based on CESM2.2.
 


### PR DESCRIPTION
The `main` branch only includes an overview of NorESM model versions. Update for noresm2.1.