### PR TITLE
Add noresm2.1 info

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -12,7 +12,7 @@ The purpose of the NorESM2 User's Guide is to provide a common place for NorESM2
 | https://noresm-docs.readthedocs.io/en/noresm1/
 
 .. note::
-   You are viewing the documentation for NorESM2.1, which is a technical development version of NorESM2. If you are looking for documentation of the CMIP6 version (NorESM2.0), please refer to the `noresm2 <https://noresm-docs.readthedocs.io/en/noresm2/>`_ documentation pages. See :ref:`start` for more about the differences between NorESM2.0 and NorESM2.1.
+   You are viewing the documentation for NorESM2.1, which is a technical development version of NorESM2. If you are looking for documentation of the CMIP6 version (NorESM2.0), please refer to the `noresm2 <https://noresm-docs.readthedocs.io/en/noresm2/>`_ documentation pages. See :ref:`start` and :ref:`noresm2.1_release_notes` for more about the differences between NorESM2.0 and NorESM2.1.
 
 
 Low-key discussion forum

--- a/index.rst
+++ b/index.rst
@@ -4,21 +4,24 @@
    contain the root `toctree` directive.
 
 Welcome to the NorESM2 User's Guide!
-================================================
+====================================
 
 The purpose of the NorESM2 User's Guide is to provide a common place for NorESM2 users and developers to share information. E.g. How is the code organised? What tools are used? Which version should be run for what purpose? 
 
 | The NorESM1 version ReadTheDocs can be found here
 | https://noresm-docs.readthedocs.io/en/noresm1/
 
+.. note::
+   You are viewing the documentation for NorESM2.1, which is a technical development version of NorESM2. If you are looking for documentation of the CMIP6 version (NorESM2.0), please refer to the `noresm2 <https://noresm-docs.readthedocs.io/en/noresm2/>`_ documentation pages. See :ref:`start` for more about the differences between NorESM2.0 and NorESM2.1.
+
 
 Low-key discussion forum
----------------------------
+------------------------
 If you have a question or you can’t find the solution to a problem in the documentation, please post your question here: https://github.com/NorESMhub/NorESM/discussions
 
 
 How to contribute
-------------------
+-----------------
 We welcome contributions to the NorESM model, including bug reports and fixes, contributions for
 code improvements, and suggestions for feature enhancements or inclusion of new features. Please
 consult the `CONTRIBUTING.md <https://github.com/NorESMhub/NorESM/blob/master/CONTRIBUTING.md>`_
@@ -48,7 +51,7 @@ For obtaining news per email register to users@noresm.org at https://www.noresm.
    
 
 Search
-==================
+======
 
 * :ref:`search`
 

--- a/index.rst
+++ b/index.rst
@@ -43,6 +43,7 @@ For obtaining news per email register to users@noresm.org at https://www.noresm.
    output/noresm_output.rst
    diagnostics/diagnostics.rst
    model-description/model-description.rst
+   noresm2.1/noresm2.1.rst
    data/data.rst
    contribute/contribute.rst
    testing/systemtests.rst

--- a/noresm2.1/noresm2.1.rst
+++ b/noresm2.1/noresm2.1.rst
@@ -1,0 +1,11 @@
+.. _noresm2.1:
+
+NorESM2.1 technical development version
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+   :numbered:
+
+   noresm2.1_release_notes.rst
+   noresm2.1_test_runs.rst

--- a/noresm2.1/noresm2.1_release_notes.rst
+++ b/noresm2.1/noresm2.1_release_notes.rst
@@ -1,0 +1,4 @@
+.. _noresm2.1_release_notes:
+
+NorESM2.1 release notes
+=======================

--- a/noresm2.1/noresm2.1_test_runs.rst
+++ b/noresm2.1/noresm2.1_test_runs.rst
@@ -1,0 +1,4 @@
+.. _noresm2.1_test_runs:
+
+NorESM2.1 test runs
+===================

--- a/start.rst
+++ b/start.rst
@@ -15,6 +15,10 @@ NorESM2.1 is a technical development version of NorESM2 that includes a few bug 
 
 NorESM2.1 being a technical development version, as opposed to a scientifically supported version, implies that tests have been carried out to ensure that NorESM2.1 builds and runs for a basic set of compsets, but the model has not been tuned to produce a stable climate output and the model performance is not documented.
 
+- See :ref:`noresm2.1_release_notes` for details about changes made in the NorESM2.1 version.
+
+- See :ref:`noresm2.1_test_runs` for documentation of test runs with NorESM2.1.
+
 
 NorESM2
 ^^^^^^^

--- a/start.rst
+++ b/start.rst
@@ -2,16 +2,22 @@
 
 
 Introduction
-=============
+============
 
 NorESM2 User's Guide
 ^^^^^^^^^^^^^^^^^^^^
-
 This guide instructs both novice and experienced users on building and running NorESM2 for various experiment set ups. The chapters attempt to provide relatively detailed information on how to make, set up, build, run and modify experiments using NorESM2.
 
 
+NorESM2.1
+^^^^^^^^^
+NorESM2.1 is a technical development version of NorESM2 that includes a few bug fixes along with numerous code improvements from the NorESM2.0 release (NorESM tag release-noresm2.0.6). This implies that NorESM2.1 rely on the same make, set up, build and run procedures as NorESM2.0, but will not generally produce the same model output. We will refer to NorESM2.1 as "NorESM2" throughout this documentation.
+
+NorESM2.1 being a technical development version, as opposed to a scientifically supported version, implies that tests have been carried out to ensure that NorESM2.1 builds and runs for a basic set of compsets, but the model has not been tuned to produce a stable climate output and the model performance is not documented.
+
+
 NorESM2
-^^^^^^^^
+^^^^^^^
 The Norwegian Earth System Model version 2 (NorESM2) is an coupled Earth System Model developed by the NorESM Climate modeling Consortium (NCC). NorESM2 is based on the second version of the Community Earth System Model, CESM2 (https://www.cesm.ucar.edu/models/cesm2), developed and operated at the National Center for Atmospheric Research (NCAR), Boulder, US. 
 
 The NorESM specific development is led by the Norwegian Meteorological Institute and NORCE Norwegian Research Centre AS. Other partners involved are the University of Oslo (UiO), CICERO, Nansen Environmental and Remote Sensing Center (NERSC) and the University of Bergen (UiB). 
@@ -70,7 +76,6 @@ LM-resolution
 | https://gmd.copernicus.org/articles/special_issue20.html
 | 
 | NorESM1 Documentation is found here: https://noresm-docs.readthedocs.io/en/noresm1/  
-
 
 
 

--- a/start.rst
+++ b/start.rst
@@ -11,7 +11,7 @@ This guide instructs both novice and experienced users on building and running N
 
 NorESM2.1
 ^^^^^^^^^
-NorESM2.1 is a technical development version of NorESM2 that includes a few bug fixes along with numerous code improvements from the NorESM2.0 release (NorESM tag release-noresm2.0.6). This implies that NorESM2.1 rely on the same make, set up, build and run procedures as NorESM2.0, but will not generally produce the same model output. We will refer to NorESM2.1 as "NorESM2" throughout this documentation.
+NorESM2.1 is a technical development version of NorESM2 that includes a few bug fixes along with numerous code improvements from the NorESM2.0 release (NorESM tag release-noresm2.0.6). This implies that NorESM2.1 relies on the same compset creation, set up, build and run procedures as NorESM2.0, but will not generally produce the same model output. We will refer to NorESM2.1 as "NorESM2" throughout this documentation.
 
 NorESM2.1 being a technical development version, as opposed to a scientifically supported version, implies that tests have been carried out to ensure that NorESM2.1 builds and runs for a basic set of compsets, but the model has not been tuned to produce a stable climate output and the model performance is not documented.
 


### PR DESCRIPTION
Add note about the NorESM2.1 version on the documentation front page and main info page, and placeholders for release notes and documentation of test runs.

This is a suggestion for how we can structure the files related to the NorESM2.1 version. Please comment if you have other suggestions for the file structure.

Ref: issue #16 