### PR TITLE
Add notfound page

### DIFF
--- a/404.rst
+++ b/404.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+Page not found
+==============
+
+The page you are looking for does not exist in this version of the NorESM documentation.
+
+`Return to main page <https://noresm-docs.readthedocs.io/en/latest/>`_

--- a/conf.py
+++ b/conf.py
@@ -177,7 +177,5 @@ epub_title = project
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
 
-
-# -- Extension configuration -------------------------------------------------
-extensions = ['sphinxcontrib.bibtex']
+# A references bib file
 bibtex_bibfiles = ['references_noresm.bib']


### PR DESCRIPTION
Creates a web page to handle when a page is missing, e.g. when switching between documentation for different model versions.
This change should be made in each of the documentation branches.
Closes #32 
Fixes #33 