### PR TITLE
Update noresm2.0.8

### DIFF
--- a/access/releases_noresm20.rst
+++ b/access/releases_noresm20.rst
@@ -3,6 +3,33 @@
 Released versions of NorESM2.0
 ==============================
 
+NorESM2.0.8
+++++++++++++
+
+* Repository: NorESMhub/NorESM
+* Tag: release-noresm2.0.8
+* Commit: 539ea1b
+* Released by: TomasTorsvik
+
+Incremental release with new machine settings for Betzy.
+
+This release contains:
+----------------------
+* **Updates for running on Betzy**
+
+How to obtain this version:
+---------------------------
+::
+
+    git clone https://github.com/NorESMhub/NorESM.git
+    cd NorESM
+    git tag --list (this should give you a list of the existing tags or releases)
+    git checkout release-noresm2.0.8
+    ./manage_externals/checkout_externals
+
+
+
+
 NorESM2.0.7
 ++++++++++++
 

--- a/configurations/platforms.rst
+++ b/configurations/platforms.rst
@@ -46,6 +46,14 @@ Apply for membership in NorESM shared data storage (manager: mben@norceresearch.
 
 The run and archive directories are stored /cluster/work/users/<user_name>/
 
+NorESM requires at least Python3 for setup and building. A recommended set of modules is provided by
+::
+
+  module purge
+  module load GCCcore/11.3.0
+  module load git/2.36.0-GCCcore-11.3.0-nodocs
+  module load Python/3.10.4-GCCcore-11.3.0
+
 Create a new case: ::
 
     ./create_newcase --case ../../../cases/<casename> --mach betzy --res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported


### PR DESCRIPTION
Include info about NorESM2.0.8 release, and Python3 module required for model setup/build.