### PR TITLE
Replace "latest" with "main" page

### DIFF
--- a/404.rst
+++ b/404.rst
@@ -5,4 +5,4 @@ Page not found
 
 The page you are looking for does not exist in this version of the NorESM documentation.
 
-`Return to main page <https://noresm-docs.readthedocs.io/en/latest/>`_
+`Return to main page <https://noresm-docs.readthedocs.io/en/main/>`_

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The NorESM documentation on Read the Docs is built from the branches in this rep
 
 <img src="img/fork_NorESM-docs.png" alt="Fork NorESM documentation repository">
 
-- step 2: Go online to [NorESM documentation](https://noresm-docs.readthedocs.io/en/latest/) and whenever you would like to update the documentation, click on "Edit on GitHub".
+- step 2: Go online to [NorESM documentation](https://noresm-docs.readthedocs.io/en/main/) and whenever you would like to update the documentation, click on "Edit on GitHub".
 
 <img src="img/edit_on_github.png" alt="Edit documentation online">
 


### PR DESCRIPTION
I suggest to replace the `latest` page with a `main` page as default, since this is more consistent with how we have set up the documentation pages. I have already replaced the page name, this PR fixes link references.